### PR TITLE
Fixes to enable build of a clean clone

### DIFF
--- a/src/Library/Library.csproj
+++ b/src/Library/Library.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net4.5;netcoreapp2.0;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp20;netcoreapp11</TargetFrameworks>
     <RootNamespace>System.Linq</RootNamespace>
     <AssemblyName>FastLinq</AssemblyName>
     <Version>0.4.0</Version>
@@ -10,7 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
+    <Reference Condition="'$(TargetFramework)'=='net45'" Include="Microsoft.CSharp" />
   </ItemGroup>
-
 </Project>

--- a/src/Test/Test.csproj
+++ b/src/Test/Test.csproj
@@ -163,4 +163,7 @@
   <Import Project="..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.targets')" />
   <Import Project="..\packages\Accord.3.8.0\build\Accord.targets" Condition="Exists('..\packages\Accord.3.8.0\build\Accord.targets')" />
   <Import Project="..\packages\NBench.1.2.2\build\NBench.targets" Condition="Exists('..\packages\NBench.1.2.2\build\NBench.targets')" />
+  <PropertyGroup>
+    <PreBuildEvent>xcopy /y "$(SolutionDir)Library\bin\$(Configuration)\net45\*.dll" "$(TargetDir)"</PreBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/src/Test/Test.csproj
+++ b/src/Test/Test.csproj
@@ -163,7 +163,4 @@
   <Import Project="..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.targets')" />
   <Import Project="..\packages\Accord.3.8.0\build\Accord.targets" Condition="Exists('..\packages\Accord.3.8.0\build\Accord.targets')" />
   <Import Project="..\packages\NBench.1.2.2\build\NBench.targets" Condition="Exists('..\packages\NBench.1.2.2\build\NBench.targets')" />
-  <PropertyGroup>
-    <PreBuildEvent>xcopy /y "$(SolutionDir)Library\bin\$(Configuration)\net45\*.dll" "$(TargetDir)"</PreBuildEvent>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
I really like the idea of this library. Since it has been a while since you did any changes I'm not sure if you accept pull requests. If you do I just did a clone and noticed some warnings and errors which I fixed. 

- There were reference warnings for the .NET Core targets. To resolve this I removed the reference to Microsoft.CSharp from these target frameworks.

- I updated the target framework names according to the TFMs that can be found [here](https://docs.microsoft.com/en-us/dotnet/core/tutorials/libraries#how-to-target-net-framework). Before doing that the conditional reference didn't work.

- I added a pre-build task to copy the FastLink.dll from the output folder to enable the code generation to work with an empty output folder. Another solution would be to change the reference in all the tt-files. Not sure what's best. This required smaller changes.